### PR TITLE
Fix typos in markdown and formatting in support files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,4 @@
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
+/.idea/
 
 # File-based project format
 *.iws
@@ -33,33 +12,14 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# Cursive Clojure plugin
-.idea/replstate.xml
-
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
-.idea/
-
 # JetBrains templates
 **___jb_tmp___
-
-
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
-
-# Sonarlint plugin
-.idea/sonarlint
 
 ### Scala ###
 *.class

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 /.idea/
 
+# mpeltonen/sbt-idea plugin
+/.idea_modules/
+
 # File-based project format
 *.iws
 
 # IntelliJ
-out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
+/out/
 
 # JIRA plugin
 atlassian-ide-plugin.xml

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,8 @@ fabric.properties
 # JetBrains templates
 **___jb_tmp___
 
-### Scala ###
-*.class
-*.log
-target
-project/target
+# Scala sbt
+target/
 
 # gatling-git data
 test-data

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version=2.0.0-RC5
+version = 2.0.0-RC5
 align = true
 maxColumn = 100

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -14,64 +14,63 @@ sbt "gatling:test"
 ## Configurable properties
 
 ### http.password [GIT_HTTP_PASSWORD]
-password to be used when performing git operations over HTTP
+Password to be used when performing git operations over HTTP.
 
 Default: `default_password`
 
 ### http.username [GIT_HTTP_USERNAME]
-user to be used when performing git operations over HTTP
+User to be used when performing git operations over HTTP.
 
 Default: `default_username`
 
 ### tmpFiles.basePath [TMP_BASE_PATH]
-test data (i.e. clones) used by the running scenario is stored in `TMP_BASE_PATH/TEST_DATA_DIRECTORY`.
-`TMP_BASE_PATH` defines the base path of the location on filesystem
+Test data (i.e. clones) used by the running scenario is stored in `TMP_BASE_PATH/TEST_DATA_DIRECTORY`.
+`TMP_BASE_PATH` defines the base path of the location on filesystem.
 
 Default: `/tmp`
 
 ### tmpFiles.testDataDirectory [TEST_DATA_DIRECTORY]
-test data (i.e. clones) used by the running scenario is stored in `TMP_BASE_PATH/TEST_DATA_DIRECTORY`.
-`TEST_DATA_DIRECTORY` defines the directory of the location on filesystem
+Test data (i.e. clones) used by the running scenario is stored in `TMP_BASE_PATH/TEST_DATA_DIRECTORY`.
+`TEST_DATA_DIRECTORY` defines the directory of the location on filesystem.
 
 Default: `System.currentTimeMillis`
 
 ### ssh.private_key_path [GIT_SSH_PRIVATE_KEY_PATH]
-Path to the ssh private key to be used for git operations over SSH
+Path to the ssh private key to be used for git operations over SSH.
 
 Default: `/tmp/ssh-keys/id_rsa`
 
 ### commands.push
 
 This configuration section allows to define how the code will synthesize the commits in the pushes.
-Commits will be generated with `NUM_FILES` in it, each with dimension randomly included between `MIN_CONTENT_LENGTH` and `MAX_CONTENT_LENGTH`
+Commits will be generated with `NUM_FILES` in it, each with dimension randomly included between `MIN_CONTENT_LENGTH` and `MAX_CONTENT_LENGTH`.
 
 ### commands.push.numFiles [NUM_FILES]
-Number of files included in each push
+Number of files included in each push.
 
 Default: `4`
 
 ### commands.push.minContentLength [MIN_CONTENT_LENGTH]
-Minimum content length in bytes of each file contained in the push
+Minimum content length in bytes of each file contained in the push.
 
 Default: `100`
 
 ### commands.push.maxContentLength [MAX_CONTENT_LENGTH]
-Maximum content length in bytes of each file contained in the push
+Maximum content length in bytes of each file contained in the push.
 
 Default: `10000`
 
 ### commands.push.commitPrefix [COMMIT_PREFIX]
-Prefix added to the synthetic commit messages
+Prefix added to the synthetic commit messages.
 
 Default: `empty string`
 
 ### git.commandTimeout [COMMAND_TIMEOUT]
-The timeout (in seconds) used to limit git commands duration
+The timeout (in seconds) used to limit git commands duration.
 
 Default: `30`
 
 ### git.showProgress [SHOW_PROGRESS]
 Whether to report progress on standard output during git operations.
 
-Default `true`
-
+Default: `true`

--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ sbt compile
 ### Setup
 
 If you are running SSH commands the private keys of the users used for testing need to go in `/tmp/ssh-keys`.
-The keys need to be generated this way (JSch won't validate them [otherwise](https://stackoverflow.com/questions/53134212/invalid-privatekey-when-using-jsch):
+The keys need to be generated this way (JSch won't validate them [otherwise](https://stackoverflow.com/questions/53134212/invalid-privatekey-when-using-jsch)):
 
 ```bash
 ssh-keygen -m PEM -t rsa -C "test@mail.com" -f /tmp/ssh-keys/id_rsa
 ```
 
-NOTE: Don't forget to add the public keys for the testing user(s) to your git server
+NOTE: Don't forget to add the public keys for the testing user(s) to your git server.
 
 #### Using Gatling's feeder input
 
@@ -124,14 +124,14 @@ Here below an example:
 
 Valid commands that can be specified in the `cmd` parameter are:
 
+* `clone`: clone the remote repository
 * `fetch`: run a git-upload-pack
 * `pull`: run a git-upload-pack and then merge the remote fetched head to the local branch
 * `push`: push the local ref to the remote Git server
-* `clone`: clone the remote repository
 
 The common parameters are:
 
-* `url`: The HTTP or SSH Git URL of the remote repository
+* `url`: The HTTP or SSH Git URL of the remote repository.
 * `ref-spec`: ref-spec of the `push` operation. Can be specified with a simple branch name or have
   the more general form of `local:remote` refs.
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,31 +3,31 @@ import Dependencies._
 enablePlugins(GatlingPlugin)
 
 val ponch = Developer(
-  id    = "barbasa",
-  name  = "Fabio Ponciroli",
+  id = "barbasa",
+  name = "Fabio Ponciroli",
   email = "ponch78@gmail.com",
-  url   = url("https://github.com/barbasa")
+  url = url("https://github.com/barbasa")
 )
 
 val tony = Developer(
-  id    = "syntonyze",
-  name  = "Antonio Barone",
+  id = "syntonyze",
+  name = "Antonio Barone",
   email = "syntonyze@gmail.com",
-  url   = url("https://github.com/syntonyze")
+  url = url("https://github.com/syntonyze")
 )
 
 val thomas = Developer(
-  id    = "thomasdraebing",
-  name  = "Thomas Draebing",
+  id = "thomasdraebing",
+  name = "Thomas Draebing",
   email = "thomas.draebing@sap.com",
-  url   = url("https://github.com/thomasdraebing")
+  url = url("https://github.com/thomasdraebing")
 )
 
 val luca = Developer(
-  id    = "lucamilanesio",
-  name  = "Luca Milanesio",
+  id = "lucamilanesio",
+  name = "Luca Milanesio",
   email = "luca.milanesio@gmail.com",
-  url   = url("https://github.com/lucamilanesio")
+  url = url("https://github.com/lucamilanesio")
 )
 
 lazy val root = (project in file("."))
@@ -56,13 +56,13 @@ lazy val root = (project in file("."))
     name := "gatling-git",
     libraryDependencies ++=
       gatling ++
-        Seq("io.gatling" % "gatling-core" % GatlingVersion ) ++
-        Seq("io.gatling" % "gatling-app" % GatlingVersion ) ++
+        Seq("io.gatling" % "gatling-core" % GatlingVersion) ++
+        Seq("io.gatling" % "gatling-app" % GatlingVersion) ++
         Seq("org.eclipse.jgit" % "org.eclipse.jgit" % "5.3.0.201903130848-r") ++
         Seq("com.google.inject" % "guice" % "3.0") ++
         Seq("commons-io" % "commons-io" % "2.6") ++
         Seq("com.typesafe.scala-logging" %% "scala-logging" % "3.9.2") ++
-      Seq("org.scalatest" %% "scalatest" % "3.0.1" % Test ),
+        Seq("org.scalatest" %% "scalatest" % "3.0.1" % Test),
   )
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
@@ -73,6 +73,6 @@ useGpg := true
 usePgpKeyHex("C54DAC2791F484279F956ED9F53F69D12E935B99")
 
 assemblyMergeStrategy in assembly := {
- case PathList("META-INF", xs @ _*) => MergeStrategy.discard
- case x => MergeStrategy.first
+  case PathList("META-INF", xs@_*) => MergeStrategy.discard
+  case x => MergeStrategy.first
 }


### PR DESCRIPTION
Which includes adding a missing closing parenthesis.

Also move the clone command to first in the sorted list.